### PR TITLE
Add optional script for CMake builder

### DIFF
--- a/appimagecraft/builders/cmake.py
+++ b/appimagecraft/builders/cmake.py
@@ -109,6 +109,14 @@ class CMakeBuilder(BuilderBase):
             "# make sure we're in the build directory",
             "cd {}".format(shlex.quote(build_dir)),
             "",
+        ])
+
+        if "script" in self._builder_config:
+            generator.add_line("# optional script")
+            generator.add_lines(self._builder_config["script"])
+            generator.add_line("")
+
+        generator.add_lines([
             "# build in separate directory to avoid a mess in the build dir",
             "mkdir -p cmake-build",
             "cd cmake-build",


### PR DESCRIPTION
I have to call `conda activate` before running the cmake build, therefore a new key `scripts` is introduced for the cmake build section in the `appimagecraft.yml`.