### PR TITLE
Use environment variable $ARCH when available

### DIFF
--- a/appimagecraft/generators/appimage_build_script.py
+++ b/appimagecraft/generators/appimage_build_script.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import re
 import shlex
@@ -20,7 +21,10 @@ class AppImageBuildScriptGenerator:
     def build_file(self, path: str):
         gen = BashScriptGenerator(path)
 
-        arch = self._config.get("arch", platform.machine())
+        if "ARCH" in os.environ:
+            arch = os.environ["ARCH"]
+        else:
+            arch = self._config.get("arch", platform.machine())
 
         valid_archs = ["x86_64", "i386"]
 
@@ -50,10 +54,11 @@ class AppImageBuildScriptGenerator:
         ])
 
         # export architecture, might be used by some people
-        gen.add_lines([
-            "export ARCH={}".format(shlex.quote(arch)),
-            "",
-        ])
+        if "ARCH" not in os.environ:
+            gen.add_lines([
+                "export ARCH={}".format(shlex.quote(arch)),
+                "",
+            ])
 
         gen.add_lines([
             "# fetch linuxdeploy from GitHub releases",


### PR DESCRIPTION
When the environment variable `$ARCH` is already set, it is applied and the build script doesn't need to figure out the architecture by itself. This is needed for 32bit containers in an 64bit environment and is now also in line with the linuxdeploy behaviour.